### PR TITLE
Put build badge on seperate line in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # OrderlyMarkdown
 [![Build status](https://ci.appveyor.com/api/projects/status/ubiwrb990iqn4fjy?svg=true)](https://ci.appveyor.com/project/alastairgould/orderlymarkdown)
+
 Markdown Source Formatter


### PR DESCRIPTION
Currently the build badge in on the same line as the paragraph. This looks untidy, put it on a separate line.